### PR TITLE
Release v1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@silexlabs/grapesjs-filter-styles",
-  "version": "1.3.1-canary.1",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@silexlabs/grapesjs-filter-styles",
-      "version": "1.3.1-canary.1",
+      "version": "1.3.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silexlabs/grapesjs-filter-styles",
-  "version": "1.3.1-canary.1",
+  "version": "1.3.1",
   "description": "Grapesjs Filter Styles",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
Release v1.3.1 — bump commit already published on npm and referenced by silex-meta v3.7.3.

This PR aligns `main` with the released state.